### PR TITLE
chore(deps): update dependency eslint-loader to v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-config-standard": "^11.0.0",
     "eslint-friendly-formatter": "^4.0.1",
-    "eslint-loader": "2.0.0",
+    "eslint-loader": "2.1.0",
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-node": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4048,9 +4048,9 @@ eslint-import-resolver-node@^0.3.1:
     debug "^2.6.9"
     resolve "^1.5.0"
 
-eslint-loader@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-2.0.0.tgz#d136619b5c684e36531ffc28c60a56e404608f5d"
+eslint-loader@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-2.1.0.tgz#61334c548aeb0b8e20ec3a552fb7a88c47261c6a"
   dependencies:
     loader-fs-cache "^1.0.0"
     loader-utils "^1.0.2"


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>eslint-loader</code> (<a href="https://renovatebot.com/gh/webpack-contrib/eslint-loader">source</a>) from <code>v2.0.0</code> to <code>v2.1.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v210httpsgithubcomwebpack-contribeslint-loaderblobmasterchangelogmd8203210---2018-07-19"><a href="https://renovatebot.com/gh/webpack-contrib/eslint-loader/blob/master/CHANGELOG.md#&#8203;210---2018-07-19"><code>v2.1.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack-contrib/eslint-loader/compare/2.0.0…2.1.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/webpack-contrib/eslint-loader/commit/1dc9442d9e2344b953ac88c5c416dcb79f3c690d">Add ESLint 5 support</a> by <a href="https://renovatebot.com/gh/Alex-Sokolov">@&#8203;Alex-Sokolov</a></li>
<li><a href="https://renovatebot.com/gh/webpack-contrib/eslint-loader/commit/97761d724e6fa26d8dbde4a544ddb7cb3795f568">Fix not returning execution flow control to webpack when cache option is enabled and one of the files has a linting error</a> by <a href="https://renovatebot.com/gh/nicolaslt">@&#8203;nicolaslt</a></li>
<li>dev deps updates, prettier, eslint config <a href="https://renovatebot.com/gh/webpack-contrib/eslint-loader/compare/2.0.0…2.1.0">…</a></li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>