### PR TITLE
Update dependency gatsby-plugin-sentry to ^0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gatsby-plugin-react-helmet": "^2.0.11",
     "gatsby-plugin-react-next": "^1.0.11",
     "gatsby-plugin-remove-trailing-slashes": "^1.0.9",
-    "gatsby-plugin-sentry": "^0.0.4",
+    "gatsby-plugin-sentry": "^0.1.0",
     "gatsby-plugin-sharp": "^1.6.47",
     "gatsby-plugin-styled-components": "^2.0.11",
     "gatsby-plugin-typography": "^1.7.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5091,11 +5091,11 @@ gatsby-plugin-remove-trailing-slashes@^1.0.9:
   dependencies:
     babel-runtime "^6.26.0"
 
-gatsby-plugin-sentry@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-sentry/-/gatsby-plugin-sentry-0.0.4.tgz#707a14a1ce29599c56eff1a37881b55595ee395b"
+gatsby-plugin-sentry@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-sentry/-/gatsby-plugin-sentry-0.1.0.tgz#5bbf0ccae2d22e360c1ef68f8a8f8d41a7cda128"
   dependencies:
-    babel-runtime "^6.26.0"
+    raven-js latest
 
 gatsby-plugin-sharp@^1.6.47:
   version "1.6.47"
@@ -10650,6 +10650,10 @@ range-parser@^1.0.3, range-parser@~1.2.0:
 raven-js@^3.26.1:
   version "3.26.1"
   resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.26.1.tgz#13f78804f2bed524a7283382e1bca7ab423950a3"
+
+raven-js@latest:
+  version "3.26.4"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.26.4.tgz#32aae3a63a9314467a453c94c89a364ea43707be"
 
 raw-body@2.3.2:
   version "2.3.2"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/octalmage/gatsby-plugin-sentry">gatsby-plugin-sentry</a> from <code>^0.0.4</code> to <code>^0.1.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v010httpsgithubcomoctalmagegatsby-plugin-sentrycomparev004v010"><a href="https://renovatebot.com/gh/octalmage/gatsby-plugin-sentry/compare/v0.0.4…v0.1.0"><code>v0.1.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/octalmage/gatsby-plugin-sentry/compare/v0.0.4…v0.1.0">Compare Source</a></p>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>