### PR TITLE
Update dependency eslint-config-prettier to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "codecov": "^3.0.2",
     "concurrently": "^3.5.1",
     "eslint": "^4.19.1",
-    "eslint-config-prettier": "^2.9.0",
+    "eslint-config-prettier": "^3.0.0",
     "eslint-config-standard": "^11.0.0",
     "eslint-friendly-formatter": "^4.0.1",
     "eslint-loader": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4020,11 +4020,11 @@ escodegen@1.x.x, escodegen@^1.9.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz#5ecd65174d486c22dff389fe036febf502d468a3"
+eslint-config-prettier@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-3.0.1.tgz#479214f64c1a4b344040924bfb97543db334b7b1"
   dependencies:
-    get-stdin "^5.0.1"
+    get-stdin "^6.0.0"
 
 eslint-config-standard@^11.0.0:
   version "11.0.0"


### PR DESCRIPTION
<p>This Pull Request updates devDependency <a href="https://renovatebot.com/gh/prettier/eslint-config-prettier">eslint-config-prettier</a> from <code>^2.9.0</code> to <code>^3.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v301httpsgithubcomprettiereslint-config-prettierblobmasterchangelogmdversion-301-2018-08-13"><a href="https://renovatebot.com/gh/prettier/eslint-config-prettier/blob/master/CHANGELOG.md#Version-301-2018-08-13"><code>v3.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/prettier/eslint-config-prettier/compare/v3.0.0…v3.0.1">Compare Source</a></p>
<ul>
<li>Improved: <code>eslint --print-config</code> usage instructions.</li>
</ul>
<hr />
<h3 id="v300httpsgithubcomprettiereslint-config-prettierblobmasterchangelogmdversion-300-2018-08-13"><a href="https://renovatebot.com/gh/prettier/eslint-config-prettier/blob/master/CHANGELOG.md#Version-300-2018-08-13"><code>v3.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/prettier/eslint-config-prettier/compare/v2.10.0…v3.0.0">Compare Source</a></p>
<ul>
<li>Breaking change: Dropped Node.js 4 support.</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>