### PR TITLE
Update dependency eslint-plugin-node to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-loader": "2.0.0",
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-node": "^7.0.0",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-react": "^7.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4065,6 +4065,13 @@ eslint-module-utils@^2.2.0:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
+eslint-plugin-es@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-1.3.1.tgz#5acb2565db4434803d1d46a9b4cbc94b345bd028"
+  dependencies:
+    eslint-utils "^1.3.0"
+    regexpp "^2.0.0"
+
 eslint-plugin-import@^2.12.0:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.12.0.tgz#dad31781292d6664b25317fd049d2e2b2f02205d"
@@ -4092,14 +4099,16 @@ eslint-plugin-jsx-a11y@^6.0.3:
     emoji-regex "^6.1.0"
     jsx-ast-utils "^2.0.0"
 
-eslint-plugin-node@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz#bf19642298064379315d7a4b2a75937376fa05e4"
+eslint-plugin-node@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz#a6e054e50199b2edd85518b89b4e7b323c9f36db"
   dependencies:
-    ignore "^3.3.6"
+    eslint-plugin-es "^1.3.1"
+    eslint-utils "^1.3.1"
+    ignore "^4.0.2"
     minimatch "^3.0.4"
-    resolve "^1.3.3"
-    semver "^5.4.1"
+    resolve "^1.8.1"
+    semver "^5.5.0"
 
 eslint-plugin-prettier@^2.6.0:
   version "2.6.0"
@@ -4131,6 +4140,10 @@ eslint-scope@^3.7.1, eslint-scope@~3.7.1:
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
+
+eslint-utils@^1.3.0, eslint-utils@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
 
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
@@ -6243,9 +6256,13 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.3.3, ignore@^3.3.5, ignore@^3.3.6:
+ignore@^3.3.3, ignore@^3.3.5:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
+
+ignore@^4.0.2:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
 
 imagemin-pngquant@5.0.1:
   version "5.0.1"
@@ -11232,6 +11249,10 @@ regexpp@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
 
+regexpp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.0.tgz#b2a7534a85ca1b033bcf5ce9ff8e56d4e0755365"
+
 regexpu-core@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-1.0.0.tgz#86a763f58ee4d7c2f6b102e4764050de7ed90c6b"
@@ -11632,9 +11653,15 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.3, resolve@^1.5.0, resolve@^1.6.0:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.5.0, resolve@^1.6.0:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
+  dependencies:
+    path-parse "^1.0.5"
+
+resolve@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
     path-parse "^1.0.5"
 


### PR DESCRIPTION
<p>This Pull Request updates devDependency <a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node">eslint-plugin-node</a> from <code>^6.0.1</code> to <code>^7.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v701httpsgithubcommysticateaeslint-plugin-nodereleasesv701"><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/releases/v7.0.1"><code>v7.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/compare/v7.0.0…v7.0.1">Compare Source</a></p>
<h4 id="bug-fixes">Bug fixes</h4>
<ul>
<li>It fixed false positive that the <code>node/no-unsupported-features/node-builtins</code> reports the <code>process.emitWarning</code> method on Node.js <code>&gt;=6 &lt;8</code>. It was supported since Node.js 6.0.0.</li>
</ul>
<hr />
<h3 id="v700httpsgithubcommysticateaeslint-plugin-nodereleasesv700"><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/releases/v7.0.0"><code>v7.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/compare/v6.0.1…v7.0.0">Compare Source</a></p>
<h4 id="breaking-changes">Breaking changes</h4>
<ul>
<li>It dropped the support of Node.js 4. Now it requires <code>&gt;=6</code>.</li>
<li>It dropped the support of ESLint 3. Now it requires <code>&gt;=4.19.1</code>. (the <code>node/recommended</code> preset is supporting only ESLint <code>&gt;=5.0.0</code>)</li>
<li>It updated the <code>node/recommended</code> config.<ul>
<li>changed <code>parserOptions.ecmaVersion</code> to <code>2019</code> from <code>2018</code>.</li>
<li>added <code>plugins: ["node"]</code>.</li>
<li>removed a deprecated rule: <a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/no-unsupported-features.md">node/no-unsupported-features</a>.</li>
<li>added three new rules:<ul>
<li><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/no-unsupported-features/es-builtins.md">node/no-unsupported-features/es-builtins</a></li>
<li><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/no-unsupported-features/es-syntax.md">node/no-unsupported-features/es-syntax</a></li>
<li><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/no-unsupported-features/node-builtins.md">node/no-unsupported-features/node-builtins</a>.</li></ul></li></ul></li>
<li>It updated the <a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/no-deprecated-api.md">node/no-deprecated-api</a> rule to support Node.js up to <code>10.6.0</code>.<ul>
<li>Note some assertion methods such as <code>assert.equal</code> are deprecated. Use stricter methods such as <code>assert.strictEqual</code> or the strict mode (<code>assert.strict</code>) instead.</li></ul></li>
</ul>
<h4 id="new-rules">New rules</h4>
<ul>
<li><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/no-unsupported-features/es-builtins.md">node/no-unsupported-features/es-builtins</a> … disallow unsupported ECMAScript built-in globals on the configured Node.js version.</li>
<li><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/no-unsupported-features/es-syntax.md">node/no-unsupported-features/es-syntax</a> … disallow unsupported ECMAScript syntax on the configured Node.js version.</li>
<li><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/no-unsupported-features/node-builtins.md">node/no-unsupported-features/node-builtins</a> … disallow unsupported Node.js built-in modules and globals on the configured Node.js version.</li>
<li><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/prefer-global/buffer.md">node/prefer-global/buffer</a> … enforce the use of either <code>Buffer</code> or <code>require("buffer").Buffer</code> consistently.</li>
<li><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/prefer-global/console.md">node/prefer-global/console</a> … enforce the use of either <code>console</code> or <code>require("console")</code> consistently.</li>
<li><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/prefer-global/process.md">node/prefer-global/process</a> … enforce the use of either <code>process</code> or <code>require("process")</code> consistently.</li>
<li><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/prefer-global/url-search-params.md">node/prefer-global/url-search-params</a> … enforce the use of either <code>URLSearchParams</code> or <code>require("url").URLSearchParams</code> consistently.</li>
<li><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/prefer-global/url.md">node/prefer-global/url</a> … enforce the use of either <code>URL</code> or <code>require("url").URL</code> consistently.</li>
</ul>
<h4 id="deprecated-rules">Deprecated rules</h4>
<ul>
<li><a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/no-unsupported-features.md">node/no-unsupported-features</a> was replaced by <a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/no-unsupported-features/es-builtins.md">node/no-unsupported-features/es-builtins</a> and <a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/blob/v7.0.0/docs/rules/no-unsupported-features/es-syntax.md">node/no-unsupported-features/es-syntax</a>.</li>
</ul>
<h4 id="chore">Chore</h4>
<p>I extracted the logic which detects certain globals and modules and those properties to the <a href="https://renovatebot.com/gh/mysticatea/eslint-utils#readme">eslint-utils</a> package. I wish it to be useful for your ESLint plugins.</p>
<hr />
<p>All commits: <a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/commit/5260039c77fd7e6368c1a5808f90462e5beec6f3"><code>5260039</code></a>…<a href="https://renovatebot.com/gh/mysticatea/eslint-plugin-node/commit/890ee63e98ef95ec5a27f50f42188102526d81b1"><code>890ee63</code></a></p>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>