### PR TITLE
Update dependency minio to v6 - autoclosed

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jest": "^23.1.0",
     "lint-staged": "^7.1.3",
     "lodash": "^4.17.10",
-    "minio": "^5.0.2",
+    "minio": "^6.0.0",
     "onecolor": "^3.0.5",
     "postcss": "^6.0.22",
     "postcss-cssnext": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8475,9 +8475,9 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-minio@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/minio/-/minio-5.0.2.tgz#5b18b54464a2b282387391e2bdca642fce6aa7c3"
+minio@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/minio/-/minio-6.0.0.tgz#7e514d38eaacf2264556b232f1c2c063cc6ca7ba"
   dependencies:
     async "^1.5.2"
     block-stream2 "^1.0.0"


### PR DESCRIPTION
<p>This Pull Request updates devDependency <a href="https://renovatebot.com/gh/minio/minio-js">minio</a> from <code>^5.0.2</code> to <code>^6.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="api-change-releasehttpsgithubcomminiominio-jsreleases600"><a href="https://renovatebot.com/gh/minio/minio-js/releases/6.0.0">API change release</a></h3>
<p><a href="https://renovatebot.com/gh/minio/minio-js/compare/5.0.2…6.0.0">Compare Source</a></p>
<h4 id="changelog">Changelog</h4>
<ul>
<li>adding urllink support (<a href="https://renovatebot.com/gh/minio/minio-js/issues/700">#&#8203;700</a>) (06/07/18) <Arjun Mishra></li>
<li>Added removeObjects API to delete multiple objects on S3 (<a href="https://renovatebot.com/gh/minio/minio-js/issues/697">#&#8203;697</a>) (06/08/18) <Praveen raj Mani></li>
<li>Added metadata functionality for the JS SDK (<a href="https://renovatebot.com/gh/minio/minio-js/issues/698">#&#8203;698</a>) (06/01/18) <Arjun Mishra></li>
<li>Adds 3 missing constructor parameters. (<a href="https://renovatebot.com/gh/minio/minio-js/issues/694">#&#8203;694</a>) (05/16/18) <smouli></li>
<li>Increase "wait time" for listenBucketNotification test setup (<a href="https://renovatebot.com/gh/minio/minio-js/issues/693">#&#8203;693</a>) (05/11/18) <Krishna Srinivas></li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>