### PR TITLE
Update dependency postcss to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "lodash": "^4.17.10",
     "minio": "^5.0.2",
     "onecolor": "^3.0.5",
-    "postcss": "^6.0.22",
+    "postcss": "^7.0.0",
     "postcss-cssnext": "^3.1.0",
     "postcss-custom-media": "^6.0.0",
     "postcss-import": "^11.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10366,6 +10366,14 @@ postcss@^5.0.0, postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
+postcss@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.2.tgz#7b5a109de356804e27f95a960bef0e4d5bc9bb18"
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
+
 potrace@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/potrace/-/potrace-2.1.1.tgz#79111a858197f366418845f667fe8f7fac0a79db"


### PR DESCRIPTION
<p>This Pull Request updates devDependency <a href="https://renovatebot.com/gh/postcss/postcss">postcss</a> from <code>^6.0.22</code> to <code>^7.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v702httpsgithubcompostcsspostcssblobmasterchangelogmd8203702"><a href="https://renovatebot.com/gh/postcss/postcss/blob/master/CHANGELOG.md#&#8203;702"><code>v7.0.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/postcss/postcss/compare/7.0.1…7.0.2">Compare Source</a></p>
<ul>
<li>Fix warning text (by Rui Pedro M Lima).</li>
</ul>
<hr />
<h3 id="v701httpsgithubcompostcsspostcssblobmasterchangelogmd8203701"><a href="https://renovatebot.com/gh/postcss/postcss/blob/master/CHANGELOG.md#&#8203;701"><code>v7.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/postcss/postcss/compare/7.0.0…7.0.1">Compare Source</a></p>
<ul>
<li>Fix JSDoc (by Steven Lambert).</li>
</ul>
<hr />
<h3 id="70-“president-amy”httpsgithubcompostcsspostcssreleases700"><a href="https://renovatebot.com/gh/postcss/postcss/releases/7.0.0">7.0 “President Amy”</a></h3>
<p><a href="https://renovatebot.com/gh/postcss/postcss/compare/6.0.23…7.0.0">Compare Source</a><br />
<img src="https://user-images.githubusercontent.com/19343/42777541-41cc0ce2-88ef-11e8-9530-243eb38830a6.png" align="right" width="200" height="200" alt="President Amy seal"></p>
<p>PostCSS 7.0 dropped Node.js 4 support and brought small features.</p>
<h4 id="breaking-changes">Breaking Changes</h4>
<p>We removed Node.js 4 and Node.js 9 support since it doesn’t have security updates anymore.</p>
<p>We removed IE and “dead” browsers (without security updates) from Babel’s <a href="https://renovatebot.com/gh/browserslist/browserslist">Browserslist</a>.  Don't worry, PostCSS still generate IE-compatible code. These changes affect websites which run PostCSS on client-side like CodePen.</p>
<pre><code>last 2 version
not dead
not Explorer 11
not ExplorerMobile 11
node 10
node 8
node 6</code></pre>
<h4 id="new-features">New Features</h4>
<p><a href="https://renovatebot.com/gh/nikhilgaba">@&#8203;nikhilgaba</a> <a href="https://renovatebot.com/gh/postcss/postcss/pull/1093">added</a> cute thing for plugin developers. If an error was happened in <code>Container#walk()</code> circle, PostCSS will show in stack trace CSS node, which causes this error:</p>
<pre><code>TypeError: Cannot read property '0' of undefined
    at /home/ai/Dev/test/app.css:10:4
    at plugin (plugin.js:2:4)
    at runPostCSS (runner.js:2:1)</code></pre>
<p><a href="https://renovatebot.com/gh/igorkamyshev">@&#8203;igorkamyshev</a> added <code>finally</code> method to <code>LazyResult</code> to make it compatible with the latest Promise API.</p>
<h4 id="other-changes">Other Changes</h4>
<ul>
<li>Client-side size was reduced by <a href="https://renovatebot.com/gh/ai/size-limit">Size Limit</a> feedback.</li>
<li>Add warning on calling PostCSS without plugins and syntax options.</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>