### PR TITLE
Update dependency postcss-import to v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "postcss": "^6.0.22",
     "postcss-cssnext": "^3.1.0",
     "postcss-custom-media": "^6.0.0",
-    "postcss-import": "^11.1.0",
+    "postcss-import": "^12.0.0",
     "postcss-nested": "^3.0.0",
     "prettier": "^1.13.4",
     "prismjs": "^1.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9946,11 +9946,11 @@ postcss-image-set-polyfill@^0.3.3, postcss-image-set-polyfill@^0.3.5:
     postcss "^6.0.1"
     postcss-media-query-parser "^0.2.3"
 
-postcss-import@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-11.1.0.tgz#55c9362c9192994ec68865d224419df1db2981f0"
+postcss-import@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-12.0.0.tgz#149f96a4ef0b27525c419784be8517ebd17e92c5"
   dependencies:
-    postcss "^6.0.1"
+    postcss "^7.0.1"
     postcss-value-parser "^3.2.3"
     read-cache "^1.0.0"
     resolve "^1.1.7"
@@ -10365,6 +10365,14 @@ postcss@^5.0.0, postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.
     js-base64 "^2.1.9"
     source-map "^0.5.6"
     supports-color "^3.2.3"
+
+postcss@^7.0.1:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.2.tgz#7b5a109de356804e27f95a960bef0e4d5bc9bb18"
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
 
 potrace@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
<p>This Pull Request updates devDependency <a href="https://renovatebot.com/gh/postcss/postcss-import">postcss-import</a> from <code>^11.1.0</code> to <code>^12.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v1200httpsgithubcompostcsspostcss-importblobmasterchangelogmd82031200---2018-08-04"><a href="https://renovatebot.com/gh/postcss/postcss-import/blob/master/CHANGELOG.md#&#8203;1200---2018-08-04"><code>v12.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/postcss/postcss-import/compare/11.1.0…12.0.0">Compare Source</a></p>
<ul>
<li>Removed: Support for Node.js v4</li>
<li>Changed: Uses PostCSS v7 (<a href="https://renovatebot.com/gh/postcss/postcss/releases/tag/7.0.0">https://github.com/postcss/postcss/releases/tag/7.0.0</a>)</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>