### PR TITLE
chore(deps): update dependency babel-jest to v23.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "babel-eslint": "9.0.0",
-    "babel-jest": "23.4.2",
+    "babel-jest": "23.6.0",
     "babel-plugin-lodash": "3.3.4",
     "babel-plugin-styled-components": "1.6.4",
     "babel-preset-env": "1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -898,7 +898,7 @@ async@^0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
 
-async@^1.3.0, async@^1.4.0, async@^1.5.0, async@^1.5.2, async@~1.5:
+async@^1.3.0, async@^1.4.0, async@^1.5.0, async@~1.5:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
@@ -1195,9 +1195,9 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-jest@23.4.2, babel-jest@^23.4.2:
-  version "23.4.2"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.4.2.tgz#f276de67798a5d68f2d6e87ff518c2f6e1609877"
+babel-jest@23.6.0:
+  version "23.6.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.6.0.tgz#a644232366557a2240a0c083da6b25786185a2f1"
   dependencies:
     babel-plugin-istanbul "^4.1.6"
     babel-preset-jest "^23.2.0"
@@ -1208,6 +1208,13 @@ babel-jest@^22.4.3:
   dependencies:
     babel-plugin-istanbul "^4.1.5"
     babel-preset-jest "^22.4.4"
+
+babel-jest@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.4.2.tgz#f276de67798a5d68f2d6e87ff518c2f6e1609877"
+  dependencies:
+    babel-plugin-istanbul "^4.1.6"
+    babel-preset-jest "^23.2.0"
 
 babel-loader@^6.0.0:
   version "6.4.1"
@@ -2083,14 +2090,6 @@ bl@^1.0.0:
 blob@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
-
-block-stream2@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/block-stream2/-/block-stream2-1.1.0.tgz#c738e3a91ba977ebb5e1fef431e13ca11d8639e2"
-  dependencies:
-    defined "^1.0.0"
-    inherits "^2.0.1"
-    readable-stream "^2.0.4"
 
 bluebird@3.5.2:
   version "3.5.2"
@@ -3010,7 +3009,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.4.8, concat-stream@^1.5.1, concat-stream@^1.5.2:
+concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.5.1, concat-stream@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
@@ -4128,10 +4127,6 @@ es5-ext@^0.10.12, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
     es6-iterator "~2.0.3"
     es6-symbol "~3.1.1"
     next-tick "1"
-
-es6-error@^2.0.2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-2.1.1.tgz#91384301ec5ed1c9a7247d1128247216f03547cd"
 
 es6-iterator@~2.0.3:
   version "2.0.3"
@@ -7668,10 +7663,6 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stream@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/json-stream/-/json-stream-1.0.0.tgz#1a3854e28d2bbeeab31cc7ddf683d2ddc5652708"
-
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -8322,7 +8313,7 @@ lodash@3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@4, lodash@4.17.10, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.2, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+lodash@4, lodash@4.17.10, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -8729,7 +8720,7 @@ mime-types@2.1.18:
   dependencies:
     mime-db "~1.33.0"
 
-mime-types@^2.1.12, mime-types@^2.1.14, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.19:
   version "2.1.19"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
   dependencies:
@@ -8807,24 +8798,6 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
 minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-
-minio@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/minio/-/minio-7.0.1.tgz#61b3a94607657ee51f91f0ada188f88c2e66553e"
-  dependencies:
-    async "^1.5.2"
-    block-stream2 "^1.0.0"
-    concat-stream "^1.4.8"
-    es6-error "^2.0.2"
-    json-stream "^1.0.0"
-    lodash "^4.14.2"
-    mime-types "^2.1.14"
-    mkdirp "^0.5.1"
-    querystring "0.2.0"
-    through2 "^0.6.5"
-    uuid "^3.1.0"
-    xml "^1.0.0"
-    xml2js "^0.4.15"
 
 minipass@^2.2.1, minipass@^2.3.3:
   version "2.3.4"
@@ -13768,7 +13741,7 @@ through2-filter@^2.0.0:
     through2 "~2.0.0"
     xtend "~4.0.0"
 
-through2@^0.6.0, through2@^0.6.1, through2@^0.6.5:
+through2@^0.6.0, through2@^0.6.1:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
   dependencies:
@@ -15001,14 +14974,14 @@ xml-parse-from-string@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz#a9029e929d3dbcded169f3c6e28238d95a5d5a28"
 
-xml2js@0.4.19, xml2js@^0.4.15, xml2js@^0.4.17, xml2js@^0.4.5:
+xml2js@0.4.19, xml2js@^0.4.17, xml2js@^0.4.5:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
 
-xml@1.0.1, xml@^1.0.0:
+xml@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
 


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>babel-jest</code> (<a href="https://renovatebot.com/gh/facebook/jest">source</a>) from <code>v23.4.2</code> to <code>v23.6.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v2360httpsgithubcomfacebookjestblobmasterchangelogmd82032360"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2360"><code>v23.6.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.4.2…v23.6.0">Compare Source</a></p>
<h5 id="features">Features</h5>
<ul>
<li><code>[jest-ci]</code> Add <code>changedSince</code> to allowed watch mode configs (<a href="https://renovatebot.com/gh/facebook/jest/pull/6955">#&#8203;6955</a>)</li>
<li><code>[babel-jest]</code> Add support for <code>babel.config.js</code> added in Babel 7.0.0 (<a href="https://renovatebot.com/gh/facebook/jest/pull/6911">#&#8203;6911</a>)</li>
</ul>
<h5 id="fixes">Fixes</h5>
<ul>
<li><code>[jest-resolve]</code> Only resolve realpath once in try-catch (<a href="https://renovatebot.com/gh/facebook/jest/pull/6925">#&#8203;6925</a>)</li>
<li><code>[expect]</code> Fix TypeError in <code>toBeInstanceOf</code> on <code>null</code> or <code>undefined</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6912">#&#8203;6912</a>)</li>
<li><code>[jest-jasmine2]</code> Throw a descriptive error if the first argument supplied to a hook was not a function (<a href="https://renovatebot.com/gh/facebook/jest/pull/6917">#&#8203;6917</a>) and (<a href="https://renovatebot.com/gh/facebook/jest/pull/6931">#&#8203;6931</a>)</li>
<li><code>[jest-circus]</code> Throw a descriptive error if the first argument supplied to a hook was not a function (<a href="https://renovatebot.com/gh/facebook/jest/pull/6917">#&#8203;6917</a>) and (<a href="https://renovatebot.com/gh/facebook/jest/pull/6931">#&#8203;6931</a>)</li>
<li><code>[expect]</code> Fix variadic custom asymmetric matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/6898">#&#8203;6898</a>)</li>
<li><code>[jest-cli]</code> Fix incorrect <code>testEnvironmentOptions</code> warning (<a href="https://renovatebot.com/gh/facebook/jest/pull/6852">#&#8203;6852</a>)</li>
<li><code>[jest-each]</code> Prevent done callback being supplied to describe (<a href="https://renovatebot.com/gh/facebook/jest/pull/6843">#&#8203;6843</a>)</li>
<li><code>[jest-config]</code> Better error message for a case when a preset module was found, but no <code>jest-preset.js</code> or <code>jest-preset.json</code> at the root (<a href="https://renovatebot.com/gh/facebook/jest/pull/6863">#&#8203;6863</a>)</li>
<li><code>[jest-haste-map]</code> Catch crawler error when unsuccessfully reading directories (<a href="https://renovatebot.com/gh/facebook/jest/pull/6761">#&#8203;6761</a>)</li>
</ul>
<h5 id="chore--maintenance">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Add custom toMatchSnapshot matcher docs (<a href="https://renovatebot.com/gh/facebook/jest/pull/6837">#&#8203;6837</a>)</li>
<li><code>[docs]</code> Improve the documentation regarding preset configuration (<a href="https://renovatebot.com/gh/facebook/jest/issues/6864">#&#8203;6864</a>)</li>
<li><code>[docs]</code> Clarify usage of <code>--projects</code> CLI option (<a href="https://renovatebot.com/gh/facebook/jest/pull/6872">#&#8203;6872</a>)</li>
<li><code>[docs]</code> Correct <code>failure-change</code> notification mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/6878">#&#8203;6878</a>)</li>
<li><code>[scripts]</code> Don’t remove node_modules from subdirectories of presets in e2e tests (<a href="https://renovatebot.com/gh/facebook/jest/pull/6948">#&#8203;6948</a>)</li>
<li><code>[diff-sequences]</code> Double-check number of differences in tests (<a href="https://renovatebot.com/gh/facebook/jest/pull/6953">#&#8203;6953</a>)</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>