### PR TITLE
chore(deps): update dependency lodash to v4.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "husky": "0.14.3",
     "jest": "23.6.0",
     "lint-staged": "7.2.2",
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "onecolor": "3.0.5",
     "postcss": "7.0.2",
     "postcss-cssnext": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8323,6 +8323,10 @@ lodash@4.11.1:
   version "4.11.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.11.1.tgz#a32106eb8e2ec8e82c241611414773c9df15f8bc"
 
+lodash@4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>lodash</code> (<a href="https://lodash.com/">homepage</a>, <a href="https://renovatebot.com/gh/lodash/lodash">source</a>) from <code>v4.17.10</code> to <code>v4.17.11</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v41711httpsgithubcomlodashlodashcompare4171041711"><a href="https://renovatebot.com/gh/lodash/lodash/compare/4.17.10…4.17.11"><code>v4.17.11</code></a></h3>
<p><a href="https://renovatebot.com/gh/lodash/lodash/compare/4.17.10…4.17.11">Compare Source</a></p>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>