### PR TITLE
feat(netlify): Try adding netlify caching to avoid build timeouts.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -118,7 +118,9 @@ const plugins = _.compact([
   'gatsby-plugin-remove-trailing-slashes',
   'gatsby-plugin-feed',
   'gatsby-plugin-lodash',
+  'gatsby-plugin-netlify-cache',
   // This ostensibly has to go at the end of the plugins declaration array.
+  // @see https://www.npmjs.com/package/gatsby-plugin-netlify
   'gatsby-plugin-netlify',
 ])
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gatsby-plugin-google-analytics": "1.0.31",
     "gatsby-plugin-lodash": "1.0.11",
     "gatsby-plugin-netlify": "1.0.21",
+    "gatsby-plugin-netlify-cache": "1.1.0",
     "gatsby-plugin-react-helmet": "2.0.11",
     "gatsby-plugin-react-next": "1.0.11",
     "gatsby-plugin-remove-trailing-slashes": "1.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6539,6 +6539,14 @@ gatsby-plugin-lodash@1.0.11:
     lodash "^4.17.4"
     lodash-webpack-plugin "^0.11.4"
 
+gatsby-plugin-netlify-cache@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-netlify-cache/-/gatsby-plugin-netlify-cache-1.1.0.tgz#82630a380324b2e5d0a77eed46d3e91cdb09de6f"
+  integrity sha512-4aYOiLuWE5Eltc8Jm7c9Fss4Ab3I9O/xeOWw6dRnPjEuIL5AGT6Eshsfq3CZllxC+/pbkADshGfZNoowri14ng==
+  dependencies:
+    babel-runtime "^6.26.0"
+    fs-extra "^7.0.0"
+
 gatsby-plugin-netlify@1.0.21:
   version "1.0.21"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-netlify/-/gatsby-plugin-netlify-1.0.21.tgz#a4cd6631e2c73d73177f1ce8532f125601c8c426"


### PR DESCRIPTION
This has been an ongoing pain point in the gatsby ecosystem --
you get the wonderful convenience of optimized, viewport-appropriate
images with practically no dev work — but compiling all those
permutations of image sizes can be super resource intensive, and
must be performed up-front at build time.

See e.g.,:
- https://github.com/gatsbyjs/gatsby/issues/8056

----------------------

Although this post suggests an alternative solution, doing all
building on Circle's side then triggering Netlify when the compiled
assets are ready:
- https://oioannou.com/build-on-circleci-deploy-netlify

So... we'll see.